### PR TITLE
allow building with modern ghc versions

### DIFF
--- a/husky.cabal
+++ b/husky.cabal
@@ -18,8 +18,20 @@ extra-source-files: README
 
 Executable husky
   Build-Depends:  base, readline >= 1.0.1.0, containers >= 0.1.0.0,
-                  parsec == 2.1.*, mtl >= 1.1.0.0, 
-                  old-locale >= 1.0.0.0, time >= 1.0.0.0
+                  parsec, mtl >= 1.1.0.0,
+                  time >= 1.0.0.0
   ghc-options:    -O2
   Main-Is:        husky.hs
   hs-source-dirs: src
+  other-modules:  CalculatorParser
+                  CalculatorState
+                  ErrorParser
+                  ExtraFunctions
+                  HelpParser
+                  InfoRoutines
+                  Messages
+                  Parser
+                  PrettyPrint
+                  TokenParser
+                  UnitConversionParser
+                  UnitConverter

--- a/src/InfoRoutines.hs
+++ b/src/InfoRoutines.hs
@@ -34,7 +34,6 @@ import Data.Map
 import Data.Time
 import Prelude
 import System.IO
-import System.Locale
 
 
 -- local imports

--- a/src/TokenParser.hs
+++ b/src/TokenParser.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE CPP #-}
+
 {-----------------------------------------------------------------
  
   (c) 2008-2009 Markus Dittrich 
@@ -61,6 +63,8 @@ import ExtraFunctions
 
 
 
+#if (defined(MIN_VERSION_parsec) && MIN_VERSION_parsec(3,0,0))
+#else
 {- Definitions for Applicative Parsec instance -}
 
 -- | Applicative instance for Monad
@@ -73,6 +77,7 @@ instance Applicative (GenParser s a) where
 instance Alternative (GenParser s a) where
   empty = mzero
   (<|>) = mplus
+#endif
 
 
 

--- a/src/UnitConverter.hs
+++ b/src/UnitConverter.hs
@@ -78,7 +78,7 @@ convert_unit value unit1 unit2 unitType =
 -- | helper function looking through all unit maps for a matching
 -- conversion routine
 unit_lookup :: String -> M.Map String UnitMap -> [UnitConverter]
-unit_lookup key = M.fold append_val [] 
+unit_lookup key = M.foldr append_val []
    where
      append_val entry acc = case M.lookup key entry of
                               Nothing -> acc

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,1 @@
+resolver: lts-9.21


### PR DESCRIPTION
- allow parsec3
- drop old-locale
- stack init for lts-9 (which still had readline)